### PR TITLE
[16.0][IMP] product_pricelist_direct_print_xlsx:  printing a pricelist and selecting an product category, include its child categories.

### DIFF
--- a/product_pricelist_direct_print/README.rst
+++ b/product_pricelist_direct_print/README.rst
@@ -120,12 +120,13 @@ Contributors
   * Sylvain LE GAL <https://twitter.com/legalsylvain>
 
 * `FactorLibre <https://factorlibre.com/>`_:
-  
+
   * Juan Carlos Bonilla
 
 * `Trobz <https://trobz.com/>`_:
-  
+
   * Tris Doan
+  * Chau Le
 
 Maintainers
 ~~~~~~~~~~~

--- a/product_pricelist_direct_print/i18n/product_pricelist_direct_print.pot
+++ b/product_pricelist_direct_print/i18n/product_pricelist_direct_print.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-04 10:18+0000\n"
+"PO-Revision-Date: 2024-07-04 10:18+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -254,6 +256,11 @@ msgstr ""
 #: model:ir.actions.act_window,name:product_pricelist_direct_print.action_pricelist_print
 #: model:ir.ui.menu,name:product_pricelist_direct_print.menu_product_pricelist_print
 msgid "Print Price List"
+msgstr ""
+
+#. module: product_pricelist_direct_print
+#: model:ir.model.fields,field_description:product_pricelist_direct_print.field_product_pricelist_print__print_child_categories
+msgid "Print child categories"
 msgstr ""
 
 #. module: product_pricelist_direct_print

--- a/product_pricelist_direct_print/readme/CONTRIBUTORS.rst
+++ b/product_pricelist_direct_print/readme/CONTRIBUTORS.rst
@@ -15,9 +15,10 @@
   * Sylvain LE GAL <https://twitter.com/legalsylvain>
 
 * `FactorLibre <https://factorlibre.com/>`_:
-  
+
   * Juan Carlos Bonilla
 
 * `Trobz <https://trobz.com/>`_:
-  
+
   * Tris Doan
+  * Chau Le

--- a/product_pricelist_direct_print/static/description/index.html
+++ b/product_pricelist_direct_print/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -488,6 +489,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://trobz.com/">Trobz</a>:<ul>
 <li>Tris Doan</li>
+<li>Chau Le</li>
 </ul>
 </li>
 </ul>
@@ -495,7 +497,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/product_pricelist_direct_print/wizards/product_pricelist_print.py
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print.py
@@ -66,6 +66,9 @@ class ProductPricelistPrint(models.TransientModel):
         " the last X ordered products will be obtained for the report."
     )
     summary = fields.Text()
+    print_child_categories = fields.Boolean(
+        default=True, string="Print child categories"
+    )
     max_categ_level = fields.Integer(
         string="Max category level",
         help="If this field is not 0, products are grouped at max level "
@@ -332,7 +335,17 @@ class ProductPricelistPrint(models.TransientModel):
                     )
             domain = expression.AND([domain, aux_domain])
         if self.categ_ids:
-            domain = expression.AND([domain, [("categ_id", "in", self.categ_ids.ids)]])
+            aux_domain = [("categ_id", "in", self.categ_ids.ids)]
+
+            if self.print_child_categories:
+                aux_domain = expression.OR(
+                    [
+                        aux_domain,
+                        [("categ_id", "child_of", self.categ_ids.ids)],
+                    ]
+                )
+
+            domain = expression.AND([domain, aux_domain])
         return domain
 
     def get_products_to_print(self):

--- a/product_pricelist_direct_print/wizards/product_pricelist_print_view.xml
+++ b/product_pricelist_direct_print/wizards/product_pricelist_print_view.xml
@@ -40,6 +40,7 @@
                             widget="many2many_tags"
                             attrs="{'invisible':['|',('product_tmpl_ids','!=',[]), ('product_ids','!=',[])]}"
                         />
+                        <field name="print_child_categories" />
                         <field name="show_only_defined_products" />
                         <field
                             name="show_variants"


### PR DESCRIPTION
-  option `Print child categories` in `XLSX Export Options`, if it's enabled, includes products from child categories when generating price list reports.

    - option `Print child categories`
    
     ![image](https://github.com/chaule97/product-attribute/assets/32189890/1584e0fc-36dd-40c1-8dda-ccf8b8b63d83)
    - result:
    
     ![image](https://github.com/chaule97/product-attribute/assets/32189890/2af8f8f6-b533-43f5-8f44-9bc7d8f67e11)

